### PR TITLE
probin for pltsql func/proc is not restored properly by pg_restore

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_function_probin_handler.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_function_probin_handler.c
@@ -57,7 +57,7 @@ bool pltsql_function_as_checker(const char *lang, List *as, char **prosrc_str_p,
 
 void pltsql_function_probin_writer(CreateFunctionStmt *stmt, Oid languageOid, char** probin_str_p)
 {
-	char			*langname;
+	char				*langname;
 	int 	    		probin_len;
 	Jsonb*				jb;
 
@@ -90,7 +90,7 @@ pltsql_function_probin_reader(ParseState *pstate,
 	HeapTuple	tuple;
 	int*		typmod_array = NULL;
 	char* 		probin_c = catalog_read_probin(funcid);
-	Oid		languageOid;
+	Oid			languageOid;
 	char		*langname;
 
 	tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));

--- a/test/JDBC/expected/BABEL-3166.out
+++ b/test/JDBC/expected/BABEL-3166.out
@@ -1,0 +1,39 @@
+-- psql
+-- function
+CREATE OR REPLACE FUNCTION "master_dbo"."babel_3166_func"("@a" numeric, "@b" "sys"."varchar", "@c" "sys"."varchar", "@d" "sys"."varchar", "@e" "sys"."binary")
+RETURNS "sys"."varbinary"
+LANGUAGE "pltsql"
+AS '{"version_num": "1", "typmod_array": ["1179652", "-1", "-8000", "8", "6", "8"], "original_probin": ""}',
+'BEGIN return @e end;';
+go
+
+-- Look at the probin for typmod information
+SELECT proname, probin FROM pg_proc WHERE proname = 'babel_3166_func';
+go
+~~START~~
+name#!#text
+babel_3166_func#!#{"version_num": "1", "typmod_array": ["1179652", "-1", "-8000", "8", "6", "8"], "original_probin": ""}
+~~END~~
+
+
+DROP FUNCTION "master_dbo"."babel_3166_func";
+go
+
+-- procedure
+CREATE OR REPLACE PROCEDURE "master_dbo"."babel_3166_proc"(IN "@a" numeric, IN "@b" "sys"."varchar", IN "@c" "sys"."varchar", IN "@d" "sys"."varchar", IN "@e" "sys"."binary")
+LANGUAGE "pltsql"
+AS '{"version_num": "1", "typmod_array": ["1179652", "-1", "-8000", "8", "6"], "original_probin": ""}',
+'select @e';
+go
+
+-- Look at the probin for typmod information
+SELECT proname, probin FROM pg_proc WHERE proname = 'babel_3166_proc';
+go
+~~START~~
+name#!#text
+babel_3166_proc#!#{"version_num": "1", "typmod_array": ["1179652", "-1", "-8000", "8", "6"], "original_probin": ""}
+~~END~~
+
+
+DROP PROCEDURE "master_dbo"."babel_3166_proc";
+go

--- a/test/JDBC/input/BABEL-3166.mix
+++ b/test/JDBC/input/BABEL-3166.mix
@@ -1,0 +1,29 @@
+-- psql
+-- function
+CREATE OR REPLACE FUNCTION "master_dbo"."babel_3166_func"("@a" numeric, "@b" "sys"."varchar", "@c" "sys"."varchar", "@d" "sys"."varchar", "@e" "sys"."binary")
+RETURNS "sys"."varbinary"
+LANGUAGE "pltsql"
+AS '{"version_num": "1", "typmod_array": ["1179652", "-1", "-8000", "8", "6", "8"], "original_probin": ""}',
+'BEGIN return @e end;';
+go
+
+-- Look at the probin for typmod information
+SELECT proname, probin FROM pg_proc WHERE proname = 'babel_3166_func';
+go
+
+DROP FUNCTION "master_dbo"."babel_3166_func";
+go
+
+-- procedure
+CREATE OR REPLACE PROCEDURE "master_dbo"."babel_3166_proc"(IN "@a" numeric, IN "@b" "sys"."varchar", IN "@c" "sys"."varchar", IN "@d" "sys"."varchar", IN "@e" "sys"."binary")
+LANGUAGE "pltsql"
+AS '{"version_num": "1", "typmod_array": ["1179652", "-1", "-8000", "8", "6"], "original_probin": ""}',
+'select @e';
+go
+
+-- Look at the probin for typmod information
+SELECT proname, probin FROM pg_proc WHERE proname = 'babel_3166_proc';
+go
+
+DROP PROCEDURE "master_dbo"."babel_3166_proc";
+go


### PR DESCRIPTION
Since PG does not store typmod for function/procedure’s
input and output types, we store that information in probin
for T-SQL function/procedure. However, it is not properly
recovered by pg_restore.

The reason for this is that we intentionally ignore
probin string in pltsql_function_as_checker function
and then try to generate a new probin later while creating
the function/procedure.

Fixed this by taking probin string from AS clause
if it is provided and skipping generating the new
probin during function/procedure creation.

Task: BABEL-3166
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>