### PR TITLE
MVU fails while restoring MS-TVF and procedure with T-SQL table-type

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -69,6 +69,8 @@ static const struct config_enum_entry explain_format_options[] = {
 
 extern bool Transform_null_equals;
 
+bool tsql_tabletype = false;
+
 static bool check_server_collation_name(char **newval, void **extra, GucSource source);
 static bool check_default_locale (char **newval, void **extra, GucSource source);
 static bool check_ansi_null_dflt_on (bool *newval, void **extra, GucSource source);
@@ -978,6 +980,15 @@ define_custom_variables(void)
 				 "",
 				 PGC_SIGHUP,
 				 GUC_NOT_IN_SAMPLE,
+				 NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("babelfishpg_tsql.tsql_tabletype",
+				 gettext_noop("Shows that if a table is creating a T-SQL table type"),
+				 NULL,
+				 &tsql_tabletype,
+				 false,
+				 PGC_USERSET,
+				 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 				 NULL, NULL, NULL);
 }
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -83,6 +83,7 @@
 
 extern bool escape_hatch_unique_constraint;
 extern bool pltsql_recursive_triggers;
+extern bool tsql_tabletype;
 
 extern List *babelfishpg_tsql_raw_parser(const char *str, RawParseMode mode);
 extern bool install_backend_gram_hooks();
@@ -2124,7 +2125,7 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 
 					address = CreateFunction(pstate, (CreateFunctionStmt *) parsetree);
 
-					if (tbltypStmt)
+					if (tbltypStmt || tsql_tabletype)
 					{
 						/*
 						 * Add internal dependency between the table type and
@@ -3006,6 +3007,9 @@ static void bbf_ProcessUtility(PlannedStmt *pstmt,
 		case T_CreateStmt:
 			{
 				CreateStmt *create_stmt = (CreateStmt *) parsetree;
+
+				if(tsql_tabletype)
+					create_stmt->tsql_tabletype = true;
 
 				if (prev_ProcessUtility)
 					prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,


### PR DESCRIPTION
This commit introduces a new GUC babelfishpg_tsql.tsql_tabletype
that can be set during pg_dump and then executed during pg_restore.

pg_dump will set this guc for underlying template table
for T-SQL table-type and MS-TVF. We will make use of this
guc to recreate desired dependencies of T-SQL table-type
and MS-TVF.

Task: BABEL-3192
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>