### PR TITLE
Skip ITVF's body compilation and error check for return datatype during restore

### DIFF
--- a/.github/workflows/major-version-upgrade-verification.yml
+++ b/.github/workflows/major-version-upgrade-verification.yml
@@ -8,7 +8,7 @@ jobs:
       NEW_INSTALL_DIR: postgres14
       ENGINE_VER_FROM: BABEL_1_X_DEV__PG_13_6
       EXTENSION_VER_FROM: BABEL_1_X_DEV
-      ENGINE_VER_TO: mvu-dev
+      ENGINE_VER_TO: jira-babel-3204
       EXTENSION_VER_TO: mvu-dev
 
     runs-on: ubuntu-latest

--- a/.github/workflows/major-version-upgrade-verification.yml
+++ b/.github/workflows/major-version-upgrade-verification.yml
@@ -8,7 +8,7 @@ jobs:
       NEW_INSTALL_DIR: postgres14
       ENGINE_VER_FROM: BABEL_1_X_DEV__PG_13_6
       EXTENSION_VER_FROM: BABEL_1_X_DEV
-      ENGINE_VER_TO: jira-babel-3204
+      ENGINE_VER_TO: mvu-dev
       EXTENSION_VER_TO: mvu-dev
 
     runs-on: ubuntu-latest

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -84,6 +84,7 @@
 extern bool escape_hatch_unique_constraint;
 extern bool pltsql_recursive_triggers;
 extern bool restore_tsql_tabletype;
+extern bool babelfish_dump_restore;
 
 extern List *babelfishpg_tsql_raw_parser(const char *str, RawParseMode mode);
 extern bool install_backend_gram_hooks();
@@ -4021,7 +4022,10 @@ pltsql_validator(PG_FUNCTION_ARGS)
 	proc = (Form_pg_proc) GETSTRUCT(tuple);
 
 	/* Disallow text, ntext, and image type result */
-	if (is_tsql_text_datatype(proc->prorettype) || is_tsql_ntext_datatype(proc->prorettype) || is_tsql_image_datatype(proc->prorettype))
+	if (!babelfish_dump_restore &&
+		(is_tsql_text_datatype(proc->prorettype) ||
+		 is_tsql_ntext_datatype(proc->prorettype) ||
+		 is_tsql_image_datatype(proc->prorettype)))
 	{
 		ereport(ERROR,
 			(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
@@ -4158,7 +4162,7 @@ pltsql_validator(PG_FUNCTION_ARGS)
 		 * definition list by planning the query in the function, and modifying the
 		 * pg_proc entry for this function.
 		 */
-		if (is_itvf)
+		if (is_itvf && !babelfish_dump_restore)
 		{
 			SPIPlanPtr spi_plan;
 			int spi_rc;
@@ -4235,6 +4239,7 @@ pltsql_validator(PG_FUNCTION_ARGS)
 				TargetEntry *te = (TargetEntry *) lfirst(lc);
 				int new_i;
 				Oid new_type;
+				ListCell *prev_lc;
 
 				/*
 				 * If resjunk is true then the column is a working column and should
@@ -4256,6 +4261,20 @@ pltsql_validator(PG_FUNCTION_ARGS)
 					elog(ERROR,
 						"CREATE FUNCTION failed because a column name is not specified for column %d",
 						i+1);
+				}
+
+				foreach(prev_lc, query->targetList)
+				{
+					TargetEntry *prev_te = (TargetEntry *) lfirst(prev_lc);
+
+					if (prev_te == te)
+						break;
+
+					if (strcmp(prev_te->resname, te->resname) == 0)
+						ereport(ERROR,
+								(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+								 errmsg("parameter name \"%s\" used more than once",
+								 	te->resname)));
 				}
 
 				new_i = i + numargs;

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4127,7 +4127,7 @@ pltsql_validator(PG_FUNCTION_ARGS)
 			}
 
 			/* Test-compile the function */
-			if (is_itvf)
+			if (is_itvf && !babelfish_dump_restore)
 			{
 				PLtsql_stmt_return_query *returnQueryStmt;
 				/*

--- a/test/JDBC/expected/BABEL-3204-prepare.out
+++ b/test/JDBC/expected/BABEL-3204-prepare.out
@@ -38,7 +38,7 @@ def
 
 
 -- create ITVF which returns table with text column
-CREATE FUNCTION babel_2514_text()
+CREATE FUNCTION babel_3204_text()
 RETURNS TABLE
 AS RETURN
 (
@@ -46,7 +46,7 @@ AS RETURN
 );
 go
 
-SELECT babel_2514_text();
+SELECT babel_3204_text();
 go
 ~~START~~
 text
@@ -55,7 +55,7 @@ Hello
 
 
 -- create ITVF which returns table with ntext column
-CREATE FUNCTION babel_2514_ntext()
+CREATE FUNCTION babel_3204_ntext()
 RETURNS TABLE
 AS RETURN
 (
@@ -63,7 +63,7 @@ AS RETURN
 );
 go
 
-SELECT babel_2514_ntext();
+SELECT babel_3204_ntext();
 go
 ~~START~~
 ntext
@@ -72,7 +72,7 @@ Hello
 
 
 -- create ITVF which returns table with image column
-CREATE FUNCTION babel_2514_image()
+CREATE FUNCTION babel_3204_image()
 RETURNS TABLE
 AS RETURN
 (
@@ -80,7 +80,7 @@ AS RETURN
 );
 go
 
-SELECT babel_2514_image();
+SELECT babel_3204_image();
 go
 ~~START~~
 image

--- a/test/JDBC/expected/BABEL-3204-prepare.out
+++ b/test/JDBC/expected/BABEL-3204-prepare.out
@@ -1,0 +1,89 @@
+CREATE DATABASE db_babel_3204;
+go
+
+USE db_babel_3204;
+go
+
+-- create ITVF which uses inbuilt functions
+-- function's body should not get compiled during restore
+CREATE FUNCTION babel_3204_complex_func
+(
+	@String NVARCHAR(4000),
+	@Delimiter NCHAR(1)
+)
+RETURNS TABLE
+AS
+RETURN
+(
+	WITH Split(stpos, endpos) AS
+	(
+		SELECT 0 AS stpos, CHARINDEX(@Delimiter,@String) AS endpos
+		UNION ALL
+		SELECT endpos+1, CHARINDEX(@Delimiter,@String,endpos+1)
+		FROM Split
+		WHERE endpos > 0
+	)
+	SELECT 'Value' = SUBSTRING(@String, stpos, COALESCE(NULLIF(endpos, 0), LEN(@String) + 1) - stpos)
+	FROM Split
+);
+go
+
+SELECT babel_3204_complex_func('abc def', ' ');
+go
+~~START~~
+nvarchar
+abc
+def
+~~END~~
+
+
+-- create ITVF which returns table with text column
+CREATE FUNCTION babel_2514_text()
+RETURNS TABLE
+AS RETURN
+(
+	SELECT CAST('Hello' AS TEXT) AS message
+);
+go
+
+SELECT babel_2514_text();
+go
+~~START~~
+text
+Hello
+~~END~~
+
+
+-- create ITVF which returns table with ntext column
+CREATE FUNCTION babel_2514_ntext()
+RETURNS TABLE
+AS RETURN
+(
+	SELECT CAST('Hello' AS sys.NTEXT) AS message
+);
+go
+
+SELECT babel_2514_ntext();
+go
+~~START~~
+ntext
+Hello
+~~END~~
+
+
+-- create ITVF which returns table with image column
+CREATE FUNCTION babel_2514_image()
+RETURNS TABLE
+AS RETURN
+(
+	SELECT CAST(0xFE AS sys.IMAGE) AS message
+);
+go
+
+SELECT babel_2514_image();
+go
+~~START~~
+image
+FE
+~~END~~
+

--- a/test/JDBC/expected/BABEL-3204-verify.out
+++ b/test/JDBC/expected/BABEL-3204-verify.out
@@ -10,7 +10,7 @@ def
 ~~END~~
 
 
-SELECT babel_2514_text();
+SELECT babel_3204_text();
 go
 ~~START~~
 text
@@ -18,7 +18,7 @@ Hello
 ~~END~~
 
 
-SELECT babel_2514_ntext();
+SELECT babel_3204_ntext();
 go
 ~~START~~
 ntext
@@ -26,7 +26,7 @@ Hello
 ~~END~~
 
 
-SELECT babel_2514_image();
+SELECT babel_3204_image();
 go
 ~~START~~
 image
@@ -37,13 +37,13 @@ FE
 DROP FUNCTION babel_3204_complex_func;
 go
 
-DROP FUNCTION babel_2514_text;
+DROP FUNCTION babel_3204_text;
 go
 
-DROP FUNCTION babel_2514_ntext;
+DROP FUNCTION babel_3204_ntext;
 go
 
-DROP FUNCTION babel_2514_image;
+DROP FUNCTION babel_3204_image;
 go
 
 USE master;

--- a/test/JDBC/expected/BABEL-3204-verify.out
+++ b/test/JDBC/expected/BABEL-3204-verify.out
@@ -1,0 +1,53 @@
+USE db_babel_3204;
+go
+
+SELECT babel_3204_complex_func('abc def', ' ');
+go
+~~START~~
+nvarchar
+abc
+def
+~~END~~
+
+
+SELECT babel_2514_text();
+go
+~~START~~
+text
+Hello
+~~END~~
+
+
+SELECT babel_2514_ntext();
+go
+~~START~~
+ntext
+Hello
+~~END~~
+
+
+SELECT babel_2514_image();
+go
+~~START~~
+image
+FE
+~~END~~
+
+
+DROP FUNCTION babel_3204_complex_func;
+go
+
+DROP FUNCTION babel_2514_text;
+go
+
+DROP FUNCTION babel_2514_ntext;
+go
+
+DROP FUNCTION babel_2514_image;
+go
+
+USE master;
+go
+
+DROP DATABASE db_babel_3204;
+go

--- a/test/JDBC/expected/BABEL-479.out
+++ b/test/JDBC/expected/BABEL-479.out
@@ -24,16 +24,28 @@ BEGIN
 END
 GO
 
+-- invalid sql, this should fail as user need to provide unique column names
 CREATE FUNCTION my_func2 (@a int, @b int = 20, @c int = 30, @d int)
 RETURNS TABLE
 AS
 RETURN SELECT @a, @b, @c, @d;
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: parameter name "int4" used more than once)~~
+
+
+-- valid sql
+CREATE FUNCTION my_func2 (@a int, @b int = 20, @c int = 30, @d int)
+RETURNS TABLE
+AS
+RETURN SELECT @a AS a, @b AS b, @c AS c, @d AS d;
+GO
 
 CREATE FUNCTION my_func3 (@a int, @b int = 20, @c int, @d int = 40)
 RETURNS TABLE
 AS
-RETURN SELECT @a, @b, @c, @d;
+RETURN SELECT @a AS a, @b AS b, @c AS c, @d AS d;
 GO
 
 EXEC my_proc1 @a = 10, @d = 40;

--- a/test/JDBC/input/BABEL-479.sql
+++ b/test/JDBC/input/BABEL-479.sql
@@ -24,16 +24,24 @@ BEGIN
 END
 GO
 
+-- invalid sql, this should fail as user need to provide unique column names
 CREATE FUNCTION my_func2 (@a int, @b int = 20, @c int = 30, @d int)
 RETURNS TABLE
 AS
 RETURN SELECT @a, @b, @c, @d;
 GO
 
+-- valid sql
+CREATE FUNCTION my_func2 (@a int, @b int = 20, @c int = 30, @d int)
+RETURNS TABLE
+AS
+RETURN SELECT @a AS a, @b AS b, @c AS c, @d AS d;
+GO
+
 CREATE FUNCTION my_func3 (@a int, @b int = 20, @c int, @d int = 40)
 RETURNS TABLE
 AS
-RETURN SELECT @a, @b, @c, @d;
+RETURN SELECT @a AS a, @b AS b, @c AS c, @d AS d;
 GO
 
 EXEC my_proc1 @a = 10, @d = 40;

--- a/test/JDBC/upgrade/preparation/BABEL-3204-prepare.sql
+++ b/test/JDBC/upgrade/preparation/BABEL-3204-prepare.sql
@@ -1,0 +1,68 @@
+CREATE DATABASE db_babel_3204;
+go
+
+USE db_babel_3204;
+go
+
+-- create ITVF which uses inbuilt functions
+-- function's body should not get compiled during restore
+CREATE FUNCTION babel_3204_complex_func
+(
+	@String NVARCHAR(4000),
+	@Delimiter NCHAR(1)
+)
+RETURNS TABLE
+AS
+RETURN
+(
+	WITH Split(stpos, endpos) AS
+	(
+		SELECT 0 AS stpos, CHARINDEX(@Delimiter,@String) AS endpos
+		UNION ALL
+		SELECT endpos+1, CHARINDEX(@Delimiter,@String,endpos+1)
+		FROM Split
+		WHERE endpos > 0
+	)
+	SELECT 'Value' = SUBSTRING(@String, stpos, COALESCE(NULLIF(endpos, 0), LEN(@String) + 1) - stpos)
+	FROM Split
+);
+go
+
+SELECT babel_3204_complex_func('abc def', ' ');
+go
+
+-- create ITVF which returns table with text column
+CREATE FUNCTION babel_2514_text()
+RETURNS TABLE
+AS RETURN
+(
+	SELECT CAST('Hello' AS TEXT) AS message
+);
+go
+
+SELECT babel_2514_text();
+go
+
+-- create ITVF which returns table with ntext column
+CREATE FUNCTION babel_2514_ntext()
+RETURNS TABLE
+AS RETURN
+(
+	SELECT CAST('Hello' AS sys.NTEXT) AS message
+);
+go
+
+SELECT babel_2514_ntext();
+go
+
+-- create ITVF which returns table with image column
+CREATE FUNCTION babel_2514_image()
+RETURNS TABLE
+AS RETURN
+(
+	SELECT CAST(0xFE AS sys.IMAGE) AS message
+);
+go
+
+SELECT babel_2514_image();
+go

--- a/test/JDBC/upgrade/preparation/BABEL-3204-prepare.sql
+++ b/test/JDBC/upgrade/preparation/BABEL-3204-prepare.sql
@@ -32,7 +32,7 @@ SELECT babel_3204_complex_func('abc def', ' ');
 go
 
 -- create ITVF which returns table with text column
-CREATE FUNCTION babel_2514_text()
+CREATE FUNCTION babel_3204_text()
 RETURNS TABLE
 AS RETURN
 (
@@ -40,11 +40,11 @@ AS RETURN
 );
 go
 
-SELECT babel_2514_text();
+SELECT babel_3204_text();
 go
 
 -- create ITVF which returns table with ntext column
-CREATE FUNCTION babel_2514_ntext()
+CREATE FUNCTION babel_3204_ntext()
 RETURNS TABLE
 AS RETURN
 (
@@ -52,11 +52,11 @@ AS RETURN
 );
 go
 
-SELECT babel_2514_ntext();
+SELECT babel_3204_ntext();
 go
 
 -- create ITVF which returns table with image column
-CREATE FUNCTION babel_2514_image()
+CREATE FUNCTION babel_3204_image()
 RETURNS TABLE
 AS RETURN
 (
@@ -64,5 +64,5 @@ AS RETURN
 );
 go
 
-SELECT babel_2514_image();
+SELECT babel_3204_image();
 go

--- a/test/JDBC/upgrade/verification/BABEL-3204-verify.sql
+++ b/test/JDBC/upgrade/verification/BABEL-3204-verify.sql
@@ -4,25 +4,25 @@ go
 SELECT babel_3204_complex_func('abc def', ' ');
 go
 
-SELECT babel_2514_text();
+SELECT babel_3204_text();
 go
 
-SELECT babel_2514_ntext();
+SELECT babel_3204_ntext();
 go
 
-SELECT babel_2514_image();
+SELECT babel_3204_image();
 go
 
 DROP FUNCTION babel_3204_complex_func;
 go
 
-DROP FUNCTION babel_2514_text;
+DROP FUNCTION babel_3204_text;
 go
 
-DROP FUNCTION babel_2514_ntext;
+DROP FUNCTION babel_3204_ntext;
 go
 
-DROP FUNCTION babel_2514_image;
+DROP FUNCTION babel_3204_image;
 go
 
 USE master;

--- a/test/JDBC/upgrade/verification/BABEL-3204-verify.sql
+++ b/test/JDBC/upgrade/verification/BABEL-3204-verify.sql
@@ -1,0 +1,32 @@
+USE db_babel_3204;
+go
+
+SELECT babel_3204_complex_func('abc def', ' ');
+go
+
+SELECT babel_2514_text();
+go
+
+SELECT babel_2514_ntext();
+go
+
+SELECT babel_2514_image();
+go
+
+DROP FUNCTION babel_3204_complex_func;
+go
+
+DROP FUNCTION babel_2514_text;
+go
+
+DROP FUNCTION babel_2514_ntext;
+go
+
+DROP FUNCTION babel_2514_image;
+go
+
+USE master;
+go
+
+DROP DATABASE db_babel_3204;
+go


### PR DESCRIPTION
MVU fails while restoring inline table valued functions (ITVF) due to
following two reasons:
1. Function's body compilation fails in the validator function.
2. Validator complains that PL/tsql function can't return type
     text/ntext/image.

We will use babelfishpg_tsql.dump_restore GUC to identify that
we are restoring an ITVF and skip both the body compilation and
error check during restore.
Also, prevent user to create an ITVF with duplicate column names
(disallow invalid sql in babelfish).

Task: BABEL-3204
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>