### PR TITLE
Fix MVU failure due to a function removed from a new binary

### DIFF
--- a/.github/workflows/major-version-upgrade-verification.yml
+++ b/.github/workflows/major-version-upgrade-verification.yml
@@ -159,4 +159,5 @@ jobs:
           path: |
             ~/upgrade/*.log
             ~/upgrade/*.diff
+            ~/upgrade/*.custom
             ~/${{env.OLD_INSTALL_DIR}}/data/logfile14

--- a/.github/workflows/major-version-upgrade-verification.yml
+++ b/.github/workflows/major-version-upgrade-verification.yml
@@ -159,5 +159,4 @@ jobs:
           path: |
             ~/upgrade/*.log
             ~/upgrade/*.diff
-            ~/upgrade/*.custom
             ~/${{env.OLD_INSTALL_DIR}}/data/logfile14

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1266,6 +1266,9 @@ Datum drop_all_users(PG_FUNCTION_ARGS)
 	 * cannot be an option because other user-defined procedures
 	 * are able to refer this function as well.
 	 */
+	ereport(WARNING,
+			(errcode(ERRCODE_WARNING_DEPRECATED_FEATURE),
+			 errmsg("This function has been deprecated and will no longer drop all users.")));
 	PG_RETURN_INT32(0);
 }
 

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1253,6 +1253,22 @@ gen_droprole_subcmds(const char *user)
 	return res;
 }
 
+PG_FUNCTION_INFO_V1(drop_all_users);
+Datum drop_all_users(PG_FUNCTION_ARGS)
+{
+	/*
+	 * This function has been deprecated since v2.1.
+	 * However, we cannot remove this function entirely because,
+	 * in PG13, sys.babel_drop_all_users() procedure refers it.
+	 * Without this function, MVU from PG13 to PG14 will fail.
+	 *
+	 * Removing the procedure sys.babel_drop_all_users() during pg_dump
+	 * cannot be an option because other user-defined procedures
+	 * are able to refer this function as well.
+	 */
+	PG_RETURN_INT32(0);
+}
+
 PG_FUNCTION_INFO_V1(babelfish_set_role);
 Datum
 babelfish_set_role(PG_FUNCTION_ARGS)

--- a/test/JDBC/expected/BABEL-3220.out
+++ b/test/JDBC/expected/BABEL-3220.out
@@ -1,0 +1,9 @@
+-- psql
+CREATE PROCEDURE babel_3220_drop_all_users_deprecated()
+    LANGUAGE "c"
+    AS 'babelfishpg_tsql', 'drop_all_users';
+GO
+CALL babel_3220_drop_all_users_deprecated();
+GO
+DROP PROCEDURE babel_3220_drop_all_users_deprecated;
+GO

--- a/test/JDBC/input/BABEL-3220.mix
+++ b/test/JDBC/input/BABEL-3220.mix
@@ -1,0 +1,9 @@
+-- psql
+CREATE PROCEDURE babel_3220_drop_all_users_deprecated()
+    LANGUAGE "c"
+    AS 'babelfishpg_tsql', 'drop_all_users';
+GO
+CALL babel_3220_drop_all_users_deprecated();
+GO
+DROP PROCEDURE babel_3220_drop_all_users_deprecated;
+GO


### PR DESCRIPTION
Previous commit (https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/d8b96bdc10318b346398dc64a8e78cdbfe6f3850) removed drop_all_users() function and renamed sys.babel_drop_all_users() procedure. It is fine for mVU (minor Version Upgrade) but can cause failure in MVU (Major Version Upgrade).

Error message:
```
pg_restore: from TOC entry 1248; 1255 18392 PROCEDURE babel_drop_all_users() runner
pg_restore: error: could not execute query: ERROR:  could not find function "drop_all_users" in file "/home/runner/postgres14/lib/babelfishpg_tsql.so"
Command was: CREATE PROCEDURE "sys"."babel_drop_all_users"()
    LANGUAGE "c"
    AS 'babelfishpg_tsql', 'drop_all_users';
```

So this commit revives drop_all_users() with an empty body. More specifically, we cannot remove this function entirely because, in PG13, sys.babel_drop_all_users() procedure refers it.

Removing the procedure sys.babel_drop_all_users() during pg_dump cannot be an option because other user-defined procedures are able to refer this function as well.

Task: BABEL-3220
Signed-off-by: Jungkook Lee <jungkook@amazon.com>