### PR TITLE
Fix major version upgrade workflows

### DIFF
--- a/.github/scripts/clone_engine_repo
+++ b/.github/scripts/clone_engine_repo
@@ -14,9 +14,9 @@ set -e
 # WARNING! Use "GH" instead of "GITHUB" for variable names to avoid possible
 # conflict with github workflow environment variables.
 
-# Look for a config file and read it if it's there. Intentionally use -x
+# Look for a config file and read it if it's there. Intentionally use -e
 # instead of -r so we get an error if we can't read the config file.
-if [ -x "${0}.conf" ]; then
+if [ -e "${0}.conf" ]; then
     . ${0}.conf
 fi
 

--- a/.github/scripts/clone_engine_repo
+++ b/.github/scripts/clone_engine_repo
@@ -18,7 +18,6 @@ set -e
 # instead of -r so we get an error if we can't read the config file.
 if [ -x "${0}.conf" ]; then
     . ${0}.conf
-    echo "read config file"
 fi
 
 if [ "$1" == -n ]; then

--- a/.github/scripts/clone_engine_repo
+++ b/.github/scripts/clone_engine_repo
@@ -18,6 +18,7 @@ set -e
 # instead of -r so we get an error if we can't read the config file.
 if [ -x "${0}.conf" ]; then
     . ${0}.conf
+    echo "read config file"
 fi
 
 if [ "$1" == -n ]; then

--- a/.github/workflows/major-version-upgrade-verification.yml
+++ b/.github/workflows/major-version-upgrade-verification.yml
@@ -6,10 +6,8 @@ jobs:
     env:
       OLD_INSTALL_DIR: postgres13
       NEW_INSTALL_DIR: postgres14
-      ENGINE_VER_FROM: BABEL_1_X_DEV__PG_13_6
-      EXTENSION_VER_FROM: BABEL_1_X_DEV
-      ENGINE_VER_TO: mvu-dev
-      EXTENSION_VER_TO: mvu-dev
+      ENGINE_BRANCH_FROM: BABEL_1_X_DEV__PG_13_6
+      EXTENSION_BRANCH_FROM: BABEL_1_X_DEV
 
     runs-on: ubuntu-latest
     steps:
@@ -20,12 +18,12 @@ jobs:
         if: always()
         uses: ./.github/composite-actions/install-dependencies
 
-      - name: Build Modified Postgres using ${{env.ENGINE_VER_FROM}}
+      - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_FROM}}
         id: build-modified-postgres-old
         if: always() && steps.install-dependencies.outcome == 'success'
         run: |
           cd ..
-          git clone --branch ${{env.ENGINE_VER_FROM}} https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
+          git clone --branch ${{env.ENGINE_BRANCH_FROM}} https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
           cd postgresql_modified_for_babelfish
           ./configure --prefix=$HOME/${{env.OLD_INSTALL_DIR}} --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
           make clean
@@ -45,9 +43,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: babelfish-for-postgresql/babelfish_extensions
-          ref: ${{env.EXTENSION_VER_FROM}}
+          ref: ${{env.EXTENSION_BRANCH_FROM}}
 
-      - name: Build Extensions using ${{env.EXTENSION_VER_FROM}}
+      - name: Build Extensions using ${{env.EXTENSION_BRANCH_FROM}}
         id: build-extensions-old
         if: always() && steps.compile-antlr.outcome == 'success'
         run: |
@@ -63,7 +61,7 @@ jobs:
           cd ../babelfishpg_tsql
           make && make install
       
-      - name: Install Extensions using ${{env.EXTENSION_VER_FROM}}
+      - name: Install Extensions using ${{env.EXTENSION_BRANCH_FROM}}
         id: install-extensions-old
         if: always() && steps.build-extensions-old.outcome == 'success'
         run: |
@@ -93,14 +91,8 @@ jobs:
           cd test/JDBC/
           export inputFilesPath=upgrade/preparation
           mvn test
-          cd Info
-          timestamp=`ls -Art | tail -n 1`
-          cd $timestamp
-          mkdir -p ~/upgrade
-          mv $timestamp.diff ~/upgrade/output-diff-preparation.diff
-          mv "$timestamp"_runSummary.log ~/upgrade/run-summary-preparation.log
 
-      - name: Build Modified Postgres using ${{env.ENGINE_VER_TO}}
+      - name: Build Modified Postgres using latest version
         id: build-modified-postgres-new
         if: always() && steps.run-preparation-test.outcome == 'success'
         uses: ./.github/composite-actions/build-modified-postgres
@@ -110,7 +102,7 @@ jobs:
       - name: Copy ANTLR
         run: cp "/usr/local/lib/libantlr4-runtime.so.4.9.3" ~/${{env.NEW_INSTALL_DIR}}/lib/
 
-      - name: Build Extensions using ${{env.EXTENSION_VER_TO}}
+      - name: Build Extensions using latest version
         id: build-extensions-new
         if: always() && steps.build-modified-postgres-new.outcome == 'success'
         uses: ./.github/composite-actions/build-extensions
@@ -144,18 +136,25 @@ jobs:
           cd test/JDBC/
           export inputFilesPath=upgrade/verification
           mvn test
-          cd Info
+
+      - name: Rename Test Summary Files
+        id: test-file-rename
+        if: always() && (steps.run-preparation-test.outcome == 'failure' || steps.run-verification-test.outcome == 'failure')
+        run: |
+          cd test/JDBC/Info
           timestamp=`ls -Art | tail -n 1`
           cd $timestamp
-          mv $timestamp.diff ~/upgrade/output-diff-verification.diff
-          mv "$timestamp"_runSummary.log ~/upgrade/run-summary-verification.log
+          mkdir -p ~/upgrade
+          mv $timestamp.diff ~/upgrade/output-diff.diff
+          mv "$timestamp"_runSummary.log ~/upgrade/run-summary.log
 
       - name: Upload Logs
-        if: always() && (steps.run-preparation-test.outcome == 'failure' || steps.run-pg_upgrade.outcome == 'failure' || steps.run-verification-test.outcome == 'failure')
+        if: always() && steps.test-file-rename.outcome == 'success'
         uses: actions/upload-artifact@v2
         with:
           name: upgrade-logs
           path: |
             ~/upgrade/*.log
             ~/upgrade/*.diff
-            ~/${{env.OLD_INSTALL_DIR}}/data/logfile14
+            ~/${{env.OLD_INSTALL_DIR}}/data/logfile13
+            ~/${{env.NEW_INSTALL_DIR}}/data/logfile14

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -6,10 +6,8 @@ jobs:
     env:
       OLD_INSTALL_DIR: postgres13
       NEW_INSTALL_DIR: postgres14
-      ENGINE_VER_FROM: BABEL_1_X_DEV__PG_13_6
-      EXTENSION_VER_FROM: BABEL_1_X_DEV
-      ENGINE_VER_TO: mvu-dev
-      EXTENSION_VER_TO: mvu-dev
+      ENGINE_BRANCH_FROM: BABEL_1_X_DEV__PG_13_6
+      EXTENSION_BRANCH_FROM: BABEL_1_X_DEV
 
     runs-on: ubuntu-latest
     steps:
@@ -20,12 +18,12 @@ jobs:
         if: always()
         uses: ./.github/composite-actions/install-dependencies
 
-      - name: Build Modified Postgres using ${{env.ENGINE_VER_FROM}}
+      - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_FROM}}
         id: build-modified-postgres-old
         if: always() && steps.install-dependencies.outcome == 'success'
         run: |
           cd ..
-          git clone --branch ${{env.ENGINE_VER_FROM}} https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
+          git clone --branch ${{env.ENGINE_BRANCH_FROM}} https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
           cd postgresql_modified_for_babelfish
           ./configure --prefix=$HOME/${{env.OLD_INSTALL_DIR}} --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
           make clean
@@ -45,9 +43,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: babelfish-for-postgresql/babelfish_extensions
-          ref: ${{env.EXTENSION_VER_FROM}}
+          ref: ${{env.EXTENSION_BRANCH_FROM}}
       
-      - name: Build Extensions using ${{env.EXTENSION_VER_FROM}}
+      - name: Build Extensions using ${{env.EXTENSION_BRANCH_FROM}}
         id: build-extensions-old
         if: always() && steps.compile-antlr.outcome == 'success'
         run: |
@@ -63,7 +61,7 @@ jobs:
           cd ../babelfishpg_tsql
           make && make install
       
-      - name: Install Extensions using ${{env.EXTENSION_VER_FROM}}
+      - name: Install Extensions using ${{env.EXTENSION_BRANCH_FROM}}
         id: install-extensions-old
         if: always() && steps.build-extensions-old.outcome == 'success'
         run: |
@@ -84,7 +82,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Build Modified Postgres using ${{env.ENGINE_VER_TO}}
+      - name: Build Modified Postgres using latest version
         id: build-modified-postgres-new
         if: always() && steps.install-extensions-old.outcome == 'success'
         uses: ./.github/composite-actions/build-modified-postgres
@@ -94,7 +92,7 @@ jobs:
       - name: Copy ANTLR
         run: cp "/usr/local/lib/libantlr4-runtime.so.4.9.3" ~/${{env.NEW_INSTALL_DIR}}/lib/
 
-      - name: Build Extensions using ${{env.EXTENSION_VER_TO}}
+      - name: Build Extensions using latest version
         id: build-extensions-new
         if: always() && steps.build-modified-postgres-new.outcome == 'success'
         uses: ./.github/composite-actions/build-extensions

--- a/test/JDBC/expected/BABEL-3190-verify.out
+++ b/test/JDBC/expected/BABEL-3190-verify.out
@@ -4,7 +4,7 @@ go
 select name,max_length,precision,scale from sys.columns where object_id = OBJECT_ID('t1') order by name;
 GO
 ~~START~~
-varchar#!#smallint#!#int#!#int
+varchar#!#smallint#!#tinyint#!#tinyint
 c1#!#6#!#19#!#0
 c2#!#8#!#26#!#6
 c3#!#8#!#26#!#0


### PR DESCRIPTION
This commit brings following fixes:
1. Add a separate step to rename JDBC log files
2. Fix *`_FROM` branch names and remove unused *`_TO`
    variables as we will always test MVU to current version.
3. Fix clone_engine_repo script to use `-e` option instead of
    `-x` since `-x` is used only for executable files.
4. Fix return datatypes in upgrade test BABEL-3190 due to
    recent commit (3876dce) in upstream.

Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>