### PR TITLE
Add test cases for table name having special character

### DIFF
--- a/test/JDBC/expected/BABEL-3267-prepare.out
+++ b/test/JDBC/expected/BABEL-3267-prepare.out
@@ -1,0 +1,52 @@
+-- tsql
+CREATE DATABASE db_babel_3267;
+go
+
+USE db_babel_3267;
+go
+
+-- special character
+create table [T3267#] (c varchar(10));
+insert into [T3267#] values ('success');
+go
+~~ROW COUNT: 1~~
+
+
+-- space
+create table [T3267 a] (c varchar(10));
+insert into [T3267 a] values ('success');
+go
+~~ROW COUNT: 1~~
+
+
+-- single quote
+create table [T3267'b] (c varchar(10));
+insert into [T3267'b] values ('success');
+go
+~~ROW COUNT: 1~~
+
+
+-- backslash
+create table [T3267\c] (c varchar(10));
+insert into [T3267\c] values ('success');
+go
+~~ROW COUNT: 1~~
+
+
+
+-- double quote
+create table [T3267"d] (c varchar(10));
+insert into [T3267"d] values ('success');
+select relname, array_to_string(reloptions,',') reloptions from pg_class C where C.relname like 't3267%' order by relname;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#text
+t3267 a#!#bbf_original_rel_name=T3267 a
+t3267"d#!#bbf_original_rel_name=T3267"d
+t3267##!#bbf_original_rel_name=T3267#
+t3267'b#!#bbf_original_rel_name=T3267'b
+t3267\c#!#bbf_original_rel_name=T3267\c
+~~END~~
+

--- a/test/JDBC/expected/BABEL-3267-verify.out
+++ b/test/JDBC/expected/BABEL-3267-verify.out
@@ -1,0 +1,60 @@
+USE db_babel_3267;
+go
+
+select * from [T3267#];
+go
+~~START~~
+varchar
+success
+~~END~~
+
+
+select * from [T3267 a];
+go
+~~START~~
+varchar
+success
+~~END~~
+
+
+select * from [T3267'b];
+go
+~~START~~
+varchar
+success
+~~END~~
+
+
+select * from [T3267\c];
+go
+~~START~~
+varchar
+success
+~~END~~
+
+
+select * from [T3267"d];
+go
+~~START~~
+varchar
+success
+~~END~~
+
+
+select relname, array_to_string(reloptions,',') reloptions from pg_class C where C.relname like 't3267%' order by relname;
+go
+~~START~~
+varchar#!#text
+t3267 a#!#bbf_original_rel_name=T3267 a
+t3267"d#!#bbf_original_rel_name=T3267"d
+t3267##!#bbf_original_rel_name=T3267#
+t3267'b#!#bbf_original_rel_name=T3267'b
+t3267\c#!#bbf_original_rel_name=T3267\c
+~~END~~
+
+
+USE master;
+go
+
+DROP DATABASE db_babel_3267;
+go

--- a/test/JDBC/upgrade/preparation/BABEL-3267-prepare.mix
+++ b/test/JDBC/upgrade/preparation/BABEL-3267-prepare.mix
@@ -1,0 +1,33 @@
+-- tsql
+CREATE DATABASE db_babel_3267;
+go
+
+USE db_babel_3267;
+go
+
+-- special character
+create table [T3267#] (c varchar(10));
+insert into [T3267#] values ('success');
+go
+
+-- space
+create table [T3267 a] (c varchar(10));
+insert into [T3267 a] values ('success');
+go
+
+-- single quote
+create table [T3267'b] (c varchar(10));
+insert into [T3267'b] values ('success');
+go
+
+-- backslash
+create table [T3267\c] (c varchar(10));
+insert into [T3267\c] values ('success');
+go
+
+-- double quote
+create table [T3267"d] (c varchar(10));
+insert into [T3267"d] values ('success');
+
+select relname, array_to_string(reloptions,',') reloptions from pg_class C where C.relname like 't3267%' order by relname;
+go

--- a/test/JDBC/upgrade/verification/BABEL-3267-verify.sql
+++ b/test/JDBC/upgrade/verification/BABEL-3267-verify.sql
@@ -1,0 +1,26 @@
+USE db_babel_3267;
+go
+
+select * from [T3267#];
+go
+
+select * from [T3267 a];
+go
+
+select * from [T3267'b];
+go
+
+select * from [T3267\c];
+go
+
+select * from [T3267"d];
+go
+
+select relname, array_to_string(reloptions,',') reloptions from pg_class C where C.relname like 't3267%' order by relname;
+go
+
+USE master;
+go
+
+DROP DATABASE db_babel_3267;
+go


### PR DESCRIPTION
- Babelfish stores original relname in reloptions, so we expected
the similar issue with column name when special character is used,
but PG already handles it correctly.
- add test cases

Task: BABEL-3267
Signed-off-by: Sangil Song (sonsangi@amazon.com)