### PR TITLE
Added support for sp_droplinkedsrvlogin

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -1563,7 +1563,7 @@ openquery_imp(PG_FUNCTION_ARGS)
 
 	/* Get the foreign server and user mapping */
 	ForeignServer *server = GetForeignServerByName(text_to_cstring(PG_GETARG_TEXT_PP(0)), false);
-	UserMapping *mapping = GetUserMapping(GetUserId(), server->serverid);
+	UserMapping *mapping = GetUserMapping(GetSessionUserId(), server->serverid);
 
 	dbinit();
 
@@ -1745,7 +1745,7 @@ getOpenqueryTupdesc(char* linked_server, char* query, TupleDesc *tupdesc)
 
 	/* Get the foreign server and user mapping */
 	ForeignServer *server = GetForeignServerByName(linked_server, false);
-	UserMapping *mapping = GetUserMapping(GetUserId(), server->serverid);
+	UserMapping *mapping = GetUserMapping(GetSessionUserId(), server->serverid);
 
 	dbinit();
 

--- a/contrib/babelfishpg_tsql/sql/sys_procedures.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_procedures.sql
@@ -237,7 +237,7 @@ GRANT EXECUTE ON PROCEDURE sys.sp_addlinkedsrvlogin(IN sys.sysname,
 TO PUBLIC;
 
 CREATE OR REPLACE PROCEDURE sys.sp_droplinkedsrvlogin( IN "@rmtsrvname" sys.sysname,
-                                                      IN "@locallogin" sys.sysname DEFAULT NULL)
+                                                      IN "@locallogin" sys.sysname)
 AS 'babelfishpg_tsql', 'sp_droplinkedsrvlogin_internal'
 LANGUAGE C;
 

--- a/contrib/babelfishpg_tsql/sql/sys_procedures.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_procedures.sql
@@ -236,6 +236,15 @@ GRANT EXECUTE ON PROCEDURE sys.sp_addlinkedsrvlogin(IN sys.sysname,
                                                     IN sys.sysname)
 TO PUBLIC;
 
+CREATE OR REPLACE PROCEDURE sys.sp_droplinkedsrvlogin( IN "@rmtsrvname" sys.sysname,
+                                                      IN "@locallogin" sys.sysname DEFAULT NULL)
+AS 'babelfishpg_tsql', 'sp_droplinkedsrvlogin_internal'
+LANGUAGE C;
+
+GRANT EXECUTE ON PROCEDURE sys.sp_droplinkedsrvlogin(IN sys.sysname,
+                                                    IN sys.sysname)
+TO PUBLIC;
+
 CREATE OR REPLACE PROCEDURE sys.sp_dropserver( IN "@server" sys.sysname,
                                                     IN "@droplogins" char(10) DEFAULT NULL)
 AS 'babelfishpg_tsql', 'sp_dropserver_internal'

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2097,7 +2097,7 @@ sp_addlinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 		user->rolename = pstrdup(locallogin);
 	}
 	else {
-		user->roletype = ROLESPEC_CURRENT_USER;
+		user->roletype = ROLESPEC_PUBLIC;
 		user->location = -1;
 	}
 	CreateUserMappingStmt *stmt = makeNode(CreateUserMappingStmt);
@@ -2140,7 +2140,7 @@ sp_droplinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 		user->rolename = pstrdup(locallogin);
 	}
 	else {
-		user->roletype = ROLESPEC_CURRENT_USER;
+		user->roletype = ROLESPEC_PUBLIC;
 		user->location = -1;
 	}
 

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2090,19 +2090,25 @@ sp_addlinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 {
 	char *servername = text_to_cstring(PG_GETARG_TEXT_P(0));
 	char *locallogin = PG_ARGISNULL(2) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(2));
-	if (locallogin != NULL)
-		elog(ERROR, "Only @locallogin = NULL is supported");
-	CreateUserMappingStmt *stmt = makeNode(CreateUserMappingStmt);
 	RoleSpec *user = makeNode(RoleSpec);
+	if (locallogin != NULL){
+		// elog(ERROR, "Only @locallogin = NULL is supported");
+		user->roletype = ROLESPEC_CSTRING;
+		user->location = -1;
+		user->rolename = pstrdup(locallogin);
+	}
+	else {
+		user->roletype = ROLESPEC_CURRENT_USER;
+		user->location = -1;
+	}
+	CreateUserMappingStmt *stmt = makeNode(CreateUserMappingStmt);
 	List *options = NIL;
 	char *str = NULL;
-
+	stmt->user = user;
 	stmt->servername = servername;
 	stmt->if_not_exists = false;
 
-	user->roletype = ROLESPEC_CURRENT_USER;
-	user->location = -1;
-	stmt->user = user;
+	
 
 	/* We do not support login using user's self credentials */
 	str = text_to_cstring(PG_GETARG_TEXT_P(1));

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2092,7 +2092,6 @@ sp_addlinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 	char *locallogin = PG_ARGISNULL(2) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(2));
 	RoleSpec *user = makeNode(RoleSpec);
 	if (locallogin != NULL){
-		// elog(ERROR, "Only @locallogin = NULL is supported");
 		user->roletype = ROLESPEC_CSTRING;
 		user->location = -1;
 		user->rolename = pstrdup(locallogin);
@@ -2131,18 +2130,21 @@ sp_droplinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 {
 	char *servername = text_to_cstring(PG_GETARG_TEXT_P(0));
 	char *locallogin = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
-	if (locallogin != NULL)
-		elog(ERROR, "Only @locallogin = NULL is supported");
-
 	DropUserMappingStmt *stmt = makeNode(DropUserMappingStmt);
 	RoleSpec *user = makeNode(RoleSpec);
 	List *options = NIL;
 	char *str = NULL;
+	if (locallogin != NULL){
+		user->roletype = ROLESPEC_CSTRING;
+		user->location = -1;
+		user->rolename = pstrdup(locallogin);
+	}
+	else {
+		user->roletype = ROLESPEC_CURRENT_USER;
+		user->location = -1;
+	}
 
 	stmt->servername = servername;
-
-	user->roletype = ROLESPEC_CURRENT_USER;
-	user->location = -1;
 	stmt->user = user;
 	
 	RemoveUserMapping(stmt);

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2089,7 +2089,9 @@ Datum
 sp_addlinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 {
 	char *servername = text_to_cstring(PG_GETARG_TEXT_P(0));
-
+	char *locallogin = PG_ARGISNULL(2) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(2));
+	if (locallogin != NULL)
+		elog(ERROR, "Only @locallogin = NULL is supported");
 	CreateUserMappingStmt *stmt = makeNode(CreateUserMappingStmt);
 	RoleSpec *user = makeNode(RoleSpec);
 	List *options = NIL;
@@ -2122,6 +2124,9 @@ Datum
 sp_droplinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 {
 	char *servername = text_to_cstring(PG_GETARG_TEXT_P(0));
+	char *locallogin = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
+	if (locallogin != NULL)
+		elog(ERROR, "Only @locallogin = NULL is supported");
 
 	DropUserMappingStmt *stmt = makeNode(DropUserMappingStmt);
 	RoleSpec *user = makeNode(RoleSpec);

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -54,6 +54,7 @@ PG_FUNCTION_INFO_V1(sp_addrolemember);
 PG_FUNCTION_INFO_V1(sp_droprolemember);
 PG_FUNCTION_INFO_V1(sp_addlinkedserver_internal);
 PG_FUNCTION_INFO_V1(sp_addlinkedsrvlogin_internal);
+PG_FUNCTION_INFO_V1(sp_droplinkedsrvlogin_internal);
 PG_FUNCTION_INFO_V1(sp_dropserver_internal);
 PG_FUNCTION_INFO_V1(sp_serveroption_internal);
 PG_FUNCTION_INFO_V1(create_linked_server_procs_in_master_dbo_internal);
@@ -2113,6 +2114,27 @@ sp_addlinkedsrvlogin_internal(PG_FUNCTION_ARGS)
 	stmt->options = options;
 
 	CreateUserMapping(stmt);
+
+	return (Datum) 0;
+}
+
+Datum
+sp_droplinkedsrvlogin_internal(PG_FUNCTION_ARGS)
+{
+	char *servername = text_to_cstring(PG_GETARG_TEXT_P(0));
+
+	DropUserMappingStmt *stmt = makeNode(DropUserMappingStmt);
+	RoleSpec *user = makeNode(RoleSpec);
+	List *options = NIL;
+	char *str = NULL;
+
+	stmt->servername = servername;
+
+	user->roletype = ROLESPEC_CURRENT_USER;
+	user->location = -1;
+	stmt->user = user;
+	
+	RemoveUserMapping(stmt);
 
 	return (Datum) 0;
 }

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1543,7 +1543,6 @@ const char *unsupported_sp_procedures[] = {
 	"sp_dropalias",
 	"sp_drop_trusted_assembly",
 	"sp_dropapprole",
-	"sp_droplinkedsrvlogin",
 	"sp_droplogin",
 	"sp_dropremotelogin",
 	"sp_dropsrvrolemember",


### PR DESCRIPTION
### Description
This change adds support for `sp_droplinkedsrvlogin` which removes an existing mapping between a login on the local babelfish server and a login on the linked server.