### PR TITLE
Do not dump ROWVERSION/TIMESTAMP column values

### DIFF
--- a/test/JDBC/expected/TestRowVersion-vu-verify.out
+++ b/test/JDBC/expected/TestRowVersion-vu-verify.out
@@ -185,6 +185,15 @@ increasing
 ~~END~~
 
 
+select case when rv::int = xmin::varchar::int then 'equal' else 'not-equal' end from babel_3139_t;
+GO
+~~START~~
+text
+equal
+equal
+equal
+~~END~~
+
 
 EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_rowversion', 'strict';
 go

--- a/test/JDBC/input/datatypes/TestRowVersion-vu-verify.sql
+++ b/test/JDBC/input/datatypes/TestRowVersion-vu-verify.sql
@@ -100,6 +100,8 @@ select case when dbts_after_insert > prev_dbts then 'increasing' else 'not incre
     where prev_dbts is not null;
 go
 
+select case when rv::int = xmin::varchar::int then 'equal' else 'not-equal' end from babel_3139_t;
+GO
 
 EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_rowversion', 'strict';
 go

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -25,6 +25,7 @@ TestInt
 TestMoney
 TestNumeric
 TestReal
+TestRowVersion
 TestSmallDatetime
 TestSmallInt
 TestSmallMoney


### PR DESCRIPTION
ROWVERSION/TIMESTAMP column values should not get dumped by pg_dump, instead these columns should be recomputed in the target cluster.